### PR TITLE
Refactored Robot member variable initializations

### DIFF
--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -54,19 +54,19 @@ Robot::AutonomousInit() {
 
   //call periodic method of appropriate auto
 
-  m_shooter.Zero();
-  m_swerve.initializeOdometry(frc::Rotation2d{units::degree_t{m_navx->GetYaw()}}, initPose);
+  m_shooter->Zero();
+  m_swerve->initializeOdometry(frc::Rotation2d{units::degree_t{m_navx->GetYaw()}}, initPose);
   //initialize auto 
   m_time = 0;
   //do i need swerve initialization?
   m_intake.Deploy();
-  m_shooter.setState(Shooter::State::IDLE);
+  m_shooter->setState(Shooter::State::IDLE);
   m_intake.setState(Intake::State::IDLE);
-  m_shooter.enablelimelight();
+  m_shooter->enablelimelight();
   
   PDH.ClearStickyFaults();
   m_navx->Reset();
-  m_shooter.enablelimelight();
+  m_shooter->enablelimelight();
 }
 
 
@@ -80,7 +80,7 @@ Robot::AutonomousPeriodic() {
   //auto FSM periodic
 
   m_intake.Periodic();
-  m_shooter.Periodic(true);
+  m_shooter->Periodic(true);
 }
 
 
@@ -91,29 +91,29 @@ void
 Robot::TeleopInit() {
  
   if(m_chooser.GetSelected() == blueAlliance){
-    m_shooter.setColor(true);
+    m_shooter->setColor(true);
   } else {
-    m_shooter.setColor(false);
+    m_shooter->setColor(false);
   }
 
   m_time = 0;
   m_navx->Reset();
 
-  m_shooter.setState(Shooter::State::IDLE);
- m_shooter.enablelimelight();
- m_shooter.zeroTurret();
+  m_shooter->setState(Shooter::State::IDLE);
+ m_shooter->enablelimelight();
+ m_shooter->zeroTurret();
   m_intake.setState(Intake::State::IDLE);
 
   //REMOVE THIS WHEN AT COMPETITION!
   //should only be zeroed once, this is so that we don't have to run auto every time to test teleop
-  //m_shooter.Zero();
+  //m_shooter->Zero();
 
   //REMOVE THIS AT COMPETITION!
-  m_swerve.initializeOdometry(frc::Rotation2d{units::degree_t{m_navx->GetYaw()}}, initPose);
+  m_swerve->initializeOdometry(frc::Rotation2d{units::degree_t{m_navx->GetYaw()}}, initPose);
   
   PDH.ClearStickyFaults();
  // m_intake.Deploy();
-  //m_shooter.Periodic(false);
+  //m_shooter->Periodic(false);
   m_intake.Periodic();
   m_climber.Initialize();
 
@@ -141,28 +141,28 @@ Robot::TeleopPeriodic() {
   joy_val_to_mps(dy);
   joy_rot_to_rps(dtheta);
 
-  m_swerve.Periodic(
+  m_swerve->Periodic(
     units::meters_per_second_t{dy},
     units::meters_per_second_t{dx},
     units::radians_per_second_t{dtheta},
     units::degree_t{m_navx->GetYaw()});
 
-    frc::Pose2d pose = m_limelight->getPose(m_navx->GetYaw(), m_shooter.getTurretAngle());
+    frc::Pose2d pose = m_limelight->getPose(m_navx->GetYaw(), m_shooter->getTurretAngle());
     frc::SmartDashboard::PutNumber("Pose x", pose.X().value());
     frc::SmartDashboard::PutNumber("Pose y", pose.Y().value());
 
     // //A
     // if (xbox.GetRawButton(1)) {
-    //   m_swerve.test1ms();
+    //   m_swerve->test1ms();
     // }
     // else if (xbox.GetRawButton(2)) {
-    //   m_swerve.test2_5ms();
+    //   m_swerve->test2_5ms();
     // }
     // else if (xbox.GetRawButton(3)) {
-    //   m_swerve.test4ms();
+    //   m_swerve->test4ms();
     // }
     // else {
-    //    m_swerve.Periodic(
+    //    m_swerve->Periodic(
     //   units::meters_per_second_t{0},
     //   units::meters_per_second_t{0},
     //   units::radians_per_second_t{0},
@@ -170,7 +170,7 @@ Robot::TeleopPeriodic() {
     // }
 
 
-    // frc::ChassisSpeeds speeds = m_swerve.getSpeeds();
+    // frc::ChassisSpeeds speeds = m_swerve->getSpeeds();
     // frc::SmartDashboard::PutNumber("x speed", speeds.vx.value());
     // frc::SmartDashboard::PutNumber("y speed", speeds.vy.value());
 
@@ -203,20 +203,20 @@ Robot::TeleopPeriodic() {
     // Intake 
     else if(r_joy.GetTrigger()){
      // m_intake.setState(Intake::State::RUN); //will this cause a problem if the channel should not run?
-      m_shooter.setState(Shooter::State::LOAD);
+      m_shooter->setState(Shooter::State::LOAD);
     }
 
     //Shoot
     else if(l_joy.GetTrigger()){
-      m_shooter.setState(Shooter::State::SHOOT);
+      m_shooter->setState(Shooter::State::SHOOT);
       m_intake.setState(Intake::State::RUN);
     }
 
     //back button will enable climb
     //is raw button 4 the back button?
     else if(xbox.GetRawButton(4)){
-      m_shooter.setState(Shooter::State::CLIMB);
-      m_shooter.zeroHood();
+      m_shooter->setState(Shooter::State::CLIMB);
+      m_shooter->zeroHood();
     }
     
     // Button A will outtake
@@ -231,17 +231,17 @@ Robot::TeleopPeriodic() {
 
     // Hard point shooting location at edge of tarmac
     // else if (xbox.GetRawButton(4)){
-    //   m_shooter.setState(Shooter::State::Tarmac);
+    //   m_shooter->setState(Shooter::State::Tarmac);
     // }
 
     else { //make sure shooter and intake aren't intaking if buttons aren't pressed
-      // m_shooter.Manual(0);
-      m_shooter.setState(Shooter::State::IDLE);
+      // m_shooter->Manual(0);
+      m_shooter->setState(Shooter::State::IDLE);
       m_intake.setState(Intake::State::IDLE);
     }
     //call periodic functions so that subsystems will follow actions appropriate to their states
     m_intake.Periodic(); 
-    m_shooter.Periodic(false);
+    m_shooter->Periodic(false);
   }
   
 }
@@ -249,7 +249,7 @@ Robot::TeleopPeriodic() {
 void Robot::climbFSM() {
     m_time_climb +=m_timeStep;
     if(m_time_climb < 0.75){
-      m_shooter.Climb();
+      m_shooter->Climb();
     }
     else if(xbox.GetRawButtonPressed(2)){
       m_climber.ExtendsecondStage();
@@ -262,11 +262,11 @@ void Robot::climbFSM() {
       m_climber.armExtension(out);
     }
     else if(abs(xbox.GetRawAxis(4)) > 0.2 ){
-      m_shooter.Manual(xbox.GetRawAxis(4));
-      m_shooter.setState(Shooter::State::MANUAL);
+      m_shooter->Manual(xbox.GetRawAxis(4));
+      m_shooter->setState(Shooter::State::MANUAL);
     }
     else {
-      m_shooter.Manual(0);
+      m_shooter->Manual(0);
       m_climber.armExtension(0);
     }
 }
@@ -283,7 +283,7 @@ Robot::DisabledInit() {}
 
 void 
 Robot::DisabledPeriodic() {
- // m_swerve.DisabledPeriodic(nullptr);
+ // m_swerve->DisabledPeriodic(nullptr);
 }
 
 

--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -2,6 +2,38 @@
 #include <iostream>
 #include <frc/smartdashboard/SmartDashboard.h>
 
+static const DataLogger::DataFields datalog_fields = {
+  // {"swerve.fl.raw_yaw", DataLogger::DataType::FLOAT64},
+  // {"swerve.fl.calib_yaw", DataLogger::DataType::FLOAT64},
+  // {"swerve.fl.target_yaw", DataLogger::DataType::FLOAT64},
+  // {"swerve.fl.target_speed", DataLogger::DataType::FLOAT64},
+
+  // {"swerve.fr.raw_yaw", DataLogger::DataType::FLOAT64},
+  // {"swerve.fr.calib_yaw", DataLogger::DataType::FLOAT64},
+  // {"swerve.fr.target_yaw", DataLogger::DataType::FLOAT64},
+  // {"swerve.fr.target_speed", DataLogger::DataType::FLOAT64},
+
+  // {"swerve.fl.raw_ticks", DataLogger::DataType::FLOAT64},
+  // {"swerve.fr.raw_ticks", DataLogger::DataType::FLOAT64},
+  // {"swerve.bl.raw_ticks", DataLogger::DataType::FLOAT64},
+  // {"swerve.br.raw_ticks", DataLogger::DataType::FLOAT64},
+  
+  // {"swerve.bl.raw_yaw", DataLogger::DataType::FLOAT64},
+  // {"swerve.bl.calib_yaw", DataLogger::DataType::FLOAT64},
+  // {"swerve.bl.target_yaw", DataLogger::DataType::FLOAT64},
+  // {"swerve.bl.target_speed", DataLogger::DataType::FLOAT64},
+  // {"swerve.br.raw_yaw", DataLogger::DataType::FLOAT64},
+  // {"swerve.br.calib_yaw", DataLogger::DataType::FLOAT64},
+  // {"swerve.br.target_yaw", DataLogger::DataType::FLOAT64},
+  // {"swerve.br.target_speed", DataLogger::DataType::FLOAT64},
+  // {"swerve.teleop.dx", DataLogger::DataType::FLOAT64},
+  // {"swerve.teleop.dy", DataLogger::DataType::FLOAT64},
+  // {"swerve.teleop.dtheta", DataLogger::DataType::FLOAT64}, 
+  // {"navx.yaw", DataLogger::DataType::FLOAT64}
+     {"x_vel", DataLogger::DataType::FLOAT64},
+     {"y_vel", DataLogger::DataType::FLOAT64} 
+};
+
 // Runs once when robot is enabled
 // Sets which color we are (so we know which balls to eject), autonomous mode, and initialize navx
 // Add camera server to smartdashboard so we can see the robot's camera feed
@@ -18,22 +50,36 @@ Robot::RobotInit() {
   
   camera = frc::CameraServer::GetInstance()->StartAutomaticCapture();
 
-//  m_limelight = new Limelight();
+  try {
+    m_limelight = new Limelight();
+  } catch (const std::exception& e) {
+    std::cout << e.what() << std::endl;
+  }
   
-  // try{
-  //   m_navx = new AHRS(frc::SPI::Port::kMXP);
-  // } catch(const std::exception& e){
-  //   std::cout << e.what() <<std::endl;
-  // }
+  try {
+    m_navx = new AHRS(frc::SPI::Port::kMXP);
+  } catch(const std::exception& e) {
+    std::cout << e.what() <<std::endl;
+  }
 
-  
-  // try {
-  //   m_logger = new DataLogger(path, datalog_fields);
-  // } catch (const std::exception& e){
-  //   std::cout << e.what() <<std::endl;
-  // }
+  std::string path = "/home/lvuser/robotlog.log";
+  try {
+    m_logger = new DataLogger(path, datalog_fields);
+  } catch (const std::exception& e){
+    std::cout << e.what() <<std::endl;
+  }
 
+  try {
+    m_swerve = new Swerve(m_navx, m_logger);
+  } catch (const std::exception& e) {
+    std::cout << e.what() << std::endl;
+  }
 
+  try {
+    m_shooter = new Shooter(m_swerve, m_limelight);
+  } catch (const std::exception& e) {
+    std::cout << e.what() << std::endl;
+  }
 
   m_climbing = false;
 

--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -332,6 +332,13 @@ Robot::DisabledPeriodic() {
  // m_swerve->DisabledPeriodic(nullptr);
 }
 
+Robot::~Robot() {
+  delete m_limelight;
+  delete m_navx;
+  delete m_logger;
+  delete m_swerve;
+  delete m_shooter;
+}
 
 #ifndef RUNNING_FRC_TESTS
 int main() {

--- a/src/main/cpp/Shooter.cpp
+++ b/src/main/cpp/Shooter.cpp
@@ -3,7 +3,7 @@
 
 //sets motor configurations
 //initializes data hash map values (input is limelight y offset, output is flywheel angle and speed)
-Shooter::Shooter(Swerve& s, Limelight* l) : swerve(s) {
+Shooter::Shooter(Swerve* s, Limelight* l) : swerve(s) {
     m_limelight = l;
 
     m_flywheelMaster.SetNeutralMode(NeutralMode::Coast);

--- a/src/main/cpp/ShooterCalc.cpp
+++ b/src/main/cpp/ShooterCalc.cpp
@@ -111,7 +111,7 @@ double ShooterCalc::y_offset_to_dist(double y_offset) {
  * @param l the limelight this class is referencing
  * @param s the swerve object this class is referencing
 **/
-ShooterCalc::ShooterCalc(Limelight& l, Swerve& s) : limelight(l), swerve(s) {
+ShooterCalc::ShooterCalc(Limelight* l, Swerve* s) : limelight(l), swerve(s) {
     
     //most recent settings, may need re-tuning
     dist_to_settings[y_offset_to_dist(-20.0)] = {-1800, 12000};
@@ -160,13 +160,13 @@ ShooterCalc::ShooterCalc(Limelight& l, Swerve& s) : limelight(l), swerve(s) {
  * @returns the calculated settings object
 **/
 ShooterCalc::Settings ShooterCalc::calculate() {
-    double dist = limelight.getDist();
+    double dist = limelight->getDist();
     double time = distance_to_time(dist);
 
-    frc::ChassisSpeeds speeds = swerve.getSpeeds();
+    frc::ChassisSpeeds speeds = swerve->getSpeeds();
 
-    double RVX = getXVel(speeds.vx.value(), speeds.vy.value(), swerve.getPose());
-    double RVY = getYVel(speeds.vx.value(), speeds.vy.value(), swerve.getPose());
+    double RVX = getXVel(speeds.vx.value(), speeds.vy.value(), swerve->getPose());
+    double RVY = getYVel(speeds.vx.value(), speeds.vy.value(), swerve->getPose());
 
     frc::SmartDashboard::PutNumber("Robot X velocity", RVX);
     frc::SmartDashboard::PutNumber("Robot Y velocity", RVY);

--- a/src/main/include/Robot.h
+++ b/src/main/include/Robot.h
@@ -49,7 +49,7 @@ class Robot : public frc::TimedRobot {
   void DisabledPeriodic() override;
   void TestInit() override;
   void TestPeriodic() override;
-
+  ~Robot() override;
 
  private:
 

--- a/src/main/include/Robot.h
+++ b/src/main/include/Robot.h
@@ -37,38 +37,6 @@ double m_time = 0;
 double m_time_climb = 0;
 double m_timeStep = GeneralConstants::timeStep;
 
- static const DataLogger::DataFields datalog_fields = {
-  // {"swerve.fl.raw_yaw", DataLogger::DataType::FLOAT64},
-  // {"swerve.fl.calib_yaw", DataLogger::DataType::FLOAT64},
-  // {"swerve.fl.target_yaw", DataLogger::DataType::FLOAT64},
-  // {"swerve.fl.target_speed", DataLogger::DataType::FLOAT64},
-
-  // {"swerve.fr.raw_yaw", DataLogger::DataType::FLOAT64},
-  // {"swerve.fr.calib_yaw", DataLogger::DataType::FLOAT64},
-  // {"swerve.fr.target_yaw", DataLogger::DataType::FLOAT64},
-  // {"swerve.fr.target_speed", DataLogger::DataType::FLOAT64},
-
-  // {"swerve.fl.raw_ticks", DataLogger::DataType::FLOAT64},
-  // {"swerve.fr.raw_ticks", DataLogger::DataType::FLOAT64},
-  // {"swerve.bl.raw_ticks", DataLogger::DataType::FLOAT64},
-  // {"swerve.br.raw_ticks", DataLogger::DataType::FLOAT64},
-  
-  // {"swerve.bl.raw_yaw", DataLogger::DataType::FLOAT64},
-  // {"swerve.bl.calib_yaw", DataLogger::DataType::FLOAT64},
-  // {"swerve.bl.target_yaw", DataLogger::DataType::FLOAT64},
-  // {"swerve.bl.target_speed", DataLogger::DataType::FLOAT64},
-  // {"swerve.br.raw_yaw", DataLogger::DataType::FLOAT64},
-  // {"swerve.br.calib_yaw", DataLogger::DataType::FLOAT64},
-  // {"swerve.br.target_yaw", DataLogger::DataType::FLOAT64},
-  // {"swerve.br.target_speed", DataLogger::DataType::FLOAT64},
-  // {"swerve.teleop.dx", DataLogger::DataType::FLOAT64},
-  // {"swerve.teleop.dy", DataLogger::DataType::FLOAT64},
-  // {"swerve.teleop.dtheta", DataLogger::DataType::FLOAT64}, 
-  // {"navx.yaw", DataLogger::DataType::FLOAT64}
-     {"x_vel", DataLogger::DataType::FLOAT64},
-     {"y_vel", DataLogger::DataType::FLOAT64} 
-};
-
 class Robot : public frc::TimedRobot {
  public:
   void RobotInit() override;
@@ -91,12 +59,11 @@ class Robot : public frc::TimedRobot {
 
   void climbFSM();
 
-  AHRS *m_navx = new AHRS(frc::SPI::Port::kMXP);
+  AHRS *m_navx;
 
-  std::string path = "/home/lvuser/robotlog.log";
-  DataLogger *m_logger = new DataLogger(path, datalog_fields);
+  DataLogger *m_logger;
   
-  Limelight *m_limelight = new Limelight();
+  Limelight *m_limelight;
 
   //TODO: auto executor
   Swerve *m_swerve; // {m_navx, m_logger}; //TODO: make pointers

--- a/src/main/include/Robot.h
+++ b/src/main/include/Robot.h
@@ -66,9 +66,9 @@ class Robot : public frc::TimedRobot {
   Limelight *m_limelight;
 
   //TODO: auto executor
-  Swerve *m_swerve; // {m_navx, m_logger}; //TODO: make pointers
+  Swerve *m_swerve; 
   Intake m_intake;
-  Shooter *m_shooter; // {m_swerve, m_limelight};
+  Shooter *m_shooter;
   Climber m_climber;
   frc::Pose2d initPose; //this will need to be set as part of auto
 

--- a/src/main/include/Robot.h
+++ b/src/main/include/Robot.h
@@ -99,9 +99,9 @@ class Robot : public frc::TimedRobot {
   Limelight *m_limelight = new Limelight();
 
   //TODO: auto executor
-  Swerve m_swerve{m_navx, m_logger}; //TODO: make pointers
+  Swerve *m_swerve; // {m_navx, m_logger}; //TODO: make pointers
   Intake m_intake;
-  Shooter m_shooter{m_swerve, m_limelight};
+  Shooter *m_shooter; // {m_swerve, m_limelight};
   Climber m_climber;
   frc::Pose2d initPose; //this will need to be set as part of auto
 

--- a/src/main/include/Shooter.h
+++ b/src/main/include/Shooter.h
@@ -28,7 +28,7 @@ class Shooter{
             HOOD
         };
 
-        Shooter(Swerve& s, Limelight* l);
+        Shooter(Swerve* s, Limelight* l);
         ~Shooter();
         void Periodic(bool autonomous);
         void Aim();
@@ -65,7 +65,7 @@ class Shooter{
         //TalonFX in ticks - 0 - 20,000
         //in rpm - 0 -6000
         
-        Swerve& swerve; 
+        Swerve* swerve; 
 
         WPI_TalonFX m_flywheelMaster{ShooterConstants::shootMotorPortMaster, "rio"};
         WPI_TalonFX m_flywheelSlave{ShooterConstants::shootMotorPortSlave, "rio"};
@@ -85,7 +85,7 @@ class Shooter{
 
         Limelight * m_limelight;
 
-        ShooterCalc calc{*m_limelight, swerve};
+        ShooterCalc calc{m_limelight, swerve};
         ShooterCalc::Settings settings; //have a global settings object to be accessed in different places
 
         // Channel m_channel;

--- a/src/main/include/ShooterCalc.h
+++ b/src/main/include/ShooterCalc.h
@@ -19,7 +19,7 @@ class ShooterCalc  {
             double xoff_offset;
         };
 
-        ShooterCalc(Limelight& l, Swerve& s);
+        ShooterCalc(Limelight* l, Swerve* s);
         Settings calculate();
         //should I move this to a different class? Swerve or Limelight?
         void getPoseViaLimelight(); //TODO: write
@@ -34,8 +34,8 @@ class ShooterCalc  {
         map<double, pair<int, int>> dist_to_settings; //angle is first, speed is second
         map<double, double> dist_to_time;
 
-        Limelight& limelight;
-        Swerve& swerve;
+        Limelight* limelight;
+        Swerve* swerve;
 
         //in meters. should be pretty close?
         //TODO: confirm measurements

--- a/src/main/include/Swerve.h
+++ b/src/main/include/Swerve.h
@@ -39,9 +39,10 @@ class Swerve {
 
     private:
 
+    AHRS * m_navx;
+    
     DataLogger * m_logger{nullptr};
 
-    AHRS * m_navx;
 
     double ticksToDeg(double ticks) { 
         return frc::InputModulus(ticks, -1024.0, 1024.0) / 1024.0 * 180.0; //SHOULD result in being between -180 and 180


### PR DESCRIPTION
I refactored `m_navx`, `m_logger`, `m_limelight`, `m_swerve`, and `m_shooter` of the `Robot` class to be initialized in `RobotInit()` instead of in the header file. 

I also converted `m_swerve` and `m_shooter` to be pointers and updated references in other files as necessary. 

Additionally, I added a destructor to the `Robot` class for memory management.